### PR TITLE
Added UDCore to Plugins.json

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -78,5 +78,14 @@
         "Descriptor": "EasyLogger.uplugin",
         "StableBranch": "master",
         "ReleaseNotesURL": ""
+    },
+    {
+        "Name": "UDCore",
+        "Icon": "https://raw.githubusercontent.com/UnrealDirective/UDCore/main/Resources/Icon128.png",
+        "User": "UnrealDirective",
+        "Repo": "UDCore",
+        "Descriptor": "UDCore.uplugin",
+        "StableBranch": "main",
+        "ReleaseNotesURL": "https://udcore.unrealdirective.com/docs/changelog"
     }
 ]


### PR DESCRIPTION
I have added the open-source UDCore plugin to the list of plugins to download.

**GitHub** - https://github.com/UnrealDirective/UDCore
**Docs** - https://udcore.unrealdirective.com/docs/introduction

## About UDCore
**UDCore** (or **Unreal Directive Core**), is an open-source [Unreal Engine](https://www.unrealengine.com/) plugin that's designed from the ground-up to provide quality-of-life functionalities to enhance the development experience.
